### PR TITLE
Fix wrong jq calls and update jq-downloader repo and assets.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,8 +22,8 @@ install() {
   
   local escapedInstallVersion=$(echo $ASDF_INSTALL_VERSION | sed 's/\./\\\./g;s/\+/\\\+/g')
   local jsonResponse=$(curl -sL "${versionListUrl}" | "${JQ_BIN}" --arg VERSION "${escapedInstallVersion}" '.releases[] | select((.version + "-" + .channel) | test("^v?" + $VERSION))')
-  local jsonResponseLength=$(echo "${jsonResponse}" | jq -s 'length')
-  local filePath=$(echo "${jsonResponse}" | jq -r '.archive')
+  local jsonResponseLength=$(echo "${jsonResponse}" | "${JQ_BIN}" -s 'length')
+  local filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r '.archive')
   if [ "$(uname -s)" == "Darwin" ] && [ ${jsonResponseLength} -gt 1 ]; then
     local arch="x64"
     if [ "$(uname -m)" == "arm64" ]; then
@@ -31,7 +31,7 @@ install() {
     fi
 
     channel=$(echo "$ASDF_INSTALL_VERSION" | grep -oE '(stable|beta|dev)$' || echo "stable")
-    filePath=$(echo "${jsonResponse}" | jq -r --arg ARCH "${arch}" --arg CHANNEL "${channel}" '. | select(.dart_sdk_arch == $ARCH and .channel == $CHANNEL) | .archive')
+    filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r --arg ARCH "${arch}" --arg CHANNEL "${channel}" '. | select(.dart_sdk_arch == $ARCH and .channel == $CHANNEL) | .archive')
   fi
 
   if [ -z "${filePath}" ]; then

--- a/bin/jq-downloader
+++ b/bin/jq-downloader
@@ -4,12 +4,12 @@ get_jq_filename() {
   case "$(uname -s)" in
   Linux)
     case "$(uname -m)" in
-    x86_64) echo jq-linux64 ;;
+    x86_64) echo jq-linux-amd64 ;;
     esac ;;
   Darwin)
     case "$(uname -m)" in
-    x86_64) echo jq-osx-amd64 ;;
-    arm64) echo jq-osx-amd64 ;;
+    x86_64) echo jq-macos-amd64 ;;
+    arm64) echo jq-macos-arm64 ;;
     esac ;;
   esac
 }
@@ -19,7 +19,7 @@ download_jq_if_not_exists() {
   jq_path="$(type -p jq || echo ${currentDir}/jq)"
 
   if [[ -z "$(type -p ${jq_path})" ]]; then
-    curl -sL "https://github.com/stedolan/jq/releases/latest/download/$(get_jq_filename)" -o "${jq_path}"
+    curl -sL "https://github.com/jqlang/jq/releases/latest/download/$(get_jq_filename)" -o "${jq_path}"
     chmod +x "${jq_path}"
   fi
 


### PR DESCRIPTION
Fixes: #44
Fixes flutter download. Now you no longer have to install the jq-downloader manually.
