### PR TITLE
Fix: Prevent multi-line archive paths in install script causing curl failure

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,8 @@ install() {
     fi
 
     channel=$(echo "$ASDF_INSTALL_VERSION" | grep -oE '(stable|beta|dev)$' || echo "stable")
-    filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r --arg ARCH "${arch}" --arg CHANNEL "${channel}" '. | select(.dart_sdk_arch == $ARCH and .channel == $CHANNEL) | .archive')
+    filePath=$(echo "${jsonResponse}" | "${JQ_BIN}" -r --arg ARCH "${arch}" --arg CHANNEL "${channel}" \
+      '. | select(.dart_sdk_arch == $ARCH and .channel == $CHANNEL) | .archive' | head -n 1 )
   fi
 
   if [ -z "${filePath}" ]; then


### PR DESCRIPTION
This fixes an issue on Apple Silicon where multiple matching entries in the releases JSON
caused filePath to span multiple lines, resulting in malformed URLs during installation.

This change ensures only the first matching .archive value is used.
Tested on macOS M2 with Flutter 3.13.3-stable.